### PR TITLE
fix limits usage for calculating target flashblocks

### DIFF
--- a/src/publish.rs
+++ b/src/publish.rs
@@ -172,7 +172,7 @@ impl Step<Flashblocks> for PublishFlashblock {
 		self.capture_payload_metrics(&this_block_span);
 
 		// Increment flashblock number since we've built the flashblock
-		let next_flashblock_number = flashblock_number.advance();
+		let next_flashblock_number = flashblock_number.next();
 
 		// Place a barrier after each published flashblock to freeze the contents
 		// of the payload up to this point, since this becomes a publicly committed

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,19 +1,12 @@
 use {
 	crate::Flashblocks,
 	rblib::prelude::CheckpointContext,
-	std::{
-		fmt::Display,
-		sync::atomic::{AtomicU64, Ordering},
-	},
+	std::fmt::Display,
 };
 
 /// Current flashblock number (1-indexed).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlashblockNumber(u64);
-
-/// Number of flashblocks we're targeting to build for this block.
-#[derive(Debug, Default)]
-pub struct TargetFlashblocks(AtomicU64);
 
 impl FlashblockNumber {
 	pub fn new() -> Self {
@@ -30,7 +23,7 @@ impl FlashblockNumber {
 	}
 
 	#[must_use]
-	pub fn advance(&self) -> Self {
+	pub fn next(&self) -> Self {
 		Self(self.0 + 1)
 	}
 }
@@ -48,17 +41,3 @@ impl Display for FlashblockNumber {
 }
 
 impl CheckpointContext<Flashblocks> for FlashblockNumber {}
-
-impl TargetFlashblocks {
-	pub fn new() -> Self {
-		Self(AtomicU64::default())
-	}
-
-	pub fn get(&self) -> u64 {
-		self.0.load(Ordering::Relaxed)
-	}
-
-	pub fn set(&self, val: u64) {
-		self.0.store(val, Ordering::Relaxed);
-	}
-}

--- a/src/stop.rs
+++ b/src/stop.rs
@@ -1,16 +1,14 @@
-use {
-	crate::{Flashblocks, state::TargetFlashblocks},
-	rblib::prelude::{Checkpoint, ControlFlow, Step, StepContext},
-	std::sync::Arc,
-};
+use {crate::Flashblocks, rblib::prelude::*, std::time::Duration};
 
 pub struct BreakAfterMaxFlashblocks {
-	target_flashblocks: Arc<TargetFlashblocks>,
+	flashblock_interval: Duration,
 }
 
 impl BreakAfterMaxFlashblocks {
-	pub fn new(target_flashblocks: Arc<TargetFlashblocks>) -> Self {
-		Self { target_flashblocks }
+	pub fn new(flashblock_interval: Duration) -> Self {
+		Self {
+			flashblock_interval,
+		}
 	}
 }
 
@@ -18,9 +16,31 @@ impl Step<Flashblocks> for BreakAfterMaxFlashblocks {
 	async fn step(
 		self: std::sync::Arc<Self>,
 		payload: Checkpoint<Flashblocks>,
-		_: StepContext<Flashblocks>,
+		ctx: StepContext<Flashblocks>,
 	) -> ControlFlow<Flashblocks> {
-		if payload.context().current() <= self.target_flashblocks.get() {
+		let payload_deadline = ctx.limits().deadline.expect(
+			"Flashblock limit require its enclosing scope to have a deadline",
+		);
+
+		let payload_deadline_ms = u64::try_from(payload_deadline.as_millis())
+			.expect("payload_deadline should never exceed u64::MAX milliseconds");
+		let flashblock_interval_ms = u64::try_from(
+			self.flashblock_interval.as_millis(),
+		)
+		.expect("flashblock_interval should never exceed u64::MAX milliseconds");
+
+		let offset_ms = payload_deadline_ms % flashblock_interval_ms;
+
+		let target_flashblocks = if offset_ms == 0 {
+			// Perfect division: payload time is exact multiple of interval
+			payload_deadline_ms / flashblock_interval_ms
+		} else {
+			// Non-perfect division: add extra flashblock with shortened first
+			// interval
+			payload_deadline_ms / flashblock_interval_ms + 1
+		};
+
+		if payload.context().current() <= target_flashblocks {
 			ControlFlow::Ok(payload)
 		} else {
 			ControlFlow::Break(payload)


### PR DESCRIPTION
`FlashblocksLimits` is now stateless and target flashblocks is easily recomputed when checking if we should break

Pipeline set up is also simplified